### PR TITLE
add /usr/sbin to chroot_env in raspian.json

### DIFF
--- a/boards/raspberry-pi/raspbian.json
+++ b/boards/raspberry-pi/raspbian.json
@@ -28,7 +28,7 @@
             "mountpoint": "/"
 		}
 	],
-    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/sbin"],
+    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"],
 	"qemu_binary_source_path": "/usr/bin/qemu-arm-static",
 	"qemu_binary_destination_path": "/usr/bin/qemu-arm-static"
   }],


### PR DESCRIPTION
I needed to make this change to boards/raspberry-pi/raspbian.json so packer could find /usr/sbin/chroot on Ubuntu 18.04.