### PR TITLE
Build all boards via github actions matrix build

### DIFF
--- a/.github/workflows/all-boards.yml
+++ b/.github/workflows/all-boards.yml
@@ -1,0 +1,72 @@
+name: All
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        boards:
+          - bananapi-r1/archlinuxarm.json
+          - beaglebone-black/angstrom.json
+          - beaglebone-black/archlinuxarm.json
+          - beaglebone-black/debian.json
+          #- jetson-nano/ubuntu.json
+          - odroid-u3/archlinuxarm.json
+          - odroid-xu4/archlinuxarm.json
+          - odroid-xu4/ubuntu.json
+          - parallella/archlinuxarm.json
+          - parallella/ubuntu.json
+          - raspberry-pi/archlinuxarm.json
+          - raspberry-pi/raspbian.json
+          - wandboard/archlinuxarm.json
+    name: Build ${{ matrix.boards }} image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+          if [ -f Gopkg.toml ]; then
+              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+              dep ensure
+          fi
+      - name: Setup backports
+        run: sudo /bin/bash -c 'echo "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse" >> /etc/apt/sources.list'
+
+      - name: Fetch additional packages
+        run: sudo apt-get update && sudo apt-get install fdisk gdisk qemu-user-static libarchive-tools tar autoconf make
+
+      - name: Install newer bsdtar manually
+        run: |
+          wget https://www.libarchive.org/downloads/libarchive-3.3.2.tar.gz
+          tar xzf libarchive-3.3.2.tar.gz
+          cd libarchive-3.3.2
+          ./configure
+          make
+          sudo make install
+      - name: Build
+        run: go build -v .
+
+      - name: Fetch packer
+        run: wget https://releases.hashicorp.com/packer/1.4.5/packer_1.4.5_linux_amd64.zip && unzip -d . packer_1.4.5_linux_amd64.zip
+
+      - name: Free disk space
+        run: |
+          df -h
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
+
+      - name: Build image
+        run: sudo ./packer build boards/${{ matrix.boards }}

--- a/.github/workflows/all-boards.yml
+++ b/.github/workflows/all-boards.yml
@@ -1,5 +1,5 @@
 name: All
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/boards/jetson-nano/ubuntu.json
+++ b/boards/jetson-nano/ubuntu.json
@@ -20,7 +20,7 @@
         "mountpoint": "/"
       }
     ],
-    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/sbin"],
+    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"],
     "qemu_binary_source_path": "/usr/bin/qemu-arm-static",
     "qemu_binary_destination_path": "/usr/bin/qemu-arm-static"
   }],

--- a/boards/odroid-xu4/ubuntu.json
+++ b/boards/odroid-xu4/ubuntu.json
@@ -29,7 +29,7 @@
         "mountpoint": "/"
       }
     ],
-    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/sbin"],
+    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"],
     "qemu_binary_source_path": "/usr/bin/qemu-arm-static",
     "qemu_binary_destination_path": "/usr/bin/qemu-arm-static"
   }],

--- a/boards/parallella/archlinuxarm.json
+++ b/boards/parallella/archlinuxarm.json
@@ -45,7 +45,7 @@
         "pacman -Sy linux-parallella --noconfirm",
         "pacman -S parallella-firmware-headless-7010 --noconfirm",
 
-        "echo 'pacman -Sy paralella-examples epiphany-sdk' > /home/alarm/other_packages'"
+        "echo 'pacman -Sy paralella-examples epiphany-sdk' > /home/alarm/other_packages"
       ]
     }
   ],

--- a/boards/parallella/ubuntu.json
+++ b/boards/parallella/ubuntu.json
@@ -30,7 +30,7 @@
       }
 
     ],
-    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/sbin"],
+    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"],
     "qemu_binary_source_path": "/usr/bin/qemu-arm-static",
     "qemu_binary_destination_path": "/usr/bin/qemu-arm-static"
   }],


### PR DESCRIPTION
Also fix some minor findings in some board configurations:
* Add /usr/sbin to $PATH of image_chroot_env, otherwise chroot is not found (some boards
  already had this set, other not).
* Remove trailing tick mark in parallela/archlinuxarm.json

jetson-nano/ubuntu.json is disabled as it does not build via the github
action, even though the board builds fine locally.