### PR TITLE
raw images support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Describes the remote file that is going to be used as base image or rootfs archi
 
 The `file_unarchive_cmd` is optional and should be used if the standard golang archiver can't handle the archive format.
 
+Raw images format (`.img` or `.iso`) can be used by defining the `file_target_extension` appropriately.
+
 ## Image config
 The base image description (size, partitions, mountpoints etc).
 

--- a/builder/step_extract_and_copy_image.go
+++ b/builder/step_extract_and_copy_image.go
@@ -47,7 +47,7 @@ func (s *StepExtractAndCopyImage) Run(ctx context.Context, state multistep.State
 
 	// skip unarchive logic if provided raw image (steps: 3&4)
 	if(config.RemoteFileConfig.TargetExtension == "img" || config.RemoteFileConfig.TargetExtension == "iso") {
-        ui.Message(fmt.Sprintf("using raw image"))
+        ui.Message("using raw image")
     } else {
         // step 3: unarchive file within temporary dir
         ui.Message(fmt.Sprintf("unpacking %s to %s", archivePath, config.ImageConfig.ImagePath))


### PR DESCRIPTION
I added support for raw base images.
To skip the logic responsible for unpacking, specify `file_target_extension` as "img" or "iso" in `remote file config`.