### PR TITLE
Make base image sparse and keep the sparseness by mounting with discard

### DIFF
--- a/builder/step_create_base_image.go
+++ b/builder/step_create_base_image.go
@@ -17,16 +17,14 @@ func (s *StepCreateBaseImage) Run(ctx context.Context, state multistep.StateBag)
 	config := state.Get("config").(*Config)
 	ui := state.Get("ui").(packer.Ui)
 
-	bs := 4096
-	cnt := int(config.ImageConfig.ImageSizeBytes) / bs
-
 	ui.Message(fmt.Sprintf("creating an empty image %s", config.ImageConfig.ImagePath))
 	out, err := exec.Command(
 		"dd",
 		"if=/dev/zero",
 		fmt.Sprintf("of=%s", config.ImageConfig.ImagePath),
-		fmt.Sprintf("bs=%d", bs),
-		fmt.Sprintf("count=%d", cnt),
+		"bs=1",
+		"count=0",
+		fmt.Sprintf("seek=%d", config.ImageConfig.ImageSizeBytes),
 	).CombinedOutput()
 
 	ui.Say(fmt.Sprintf("dd output: %s", string(out)))

--- a/builder/step_mount_image.go
+++ b/builder/step_mount_image.go
@@ -76,7 +76,7 @@ func (s *StepMountImage) Run(ctx context.Context, state multistep.StateBag) mult
 		}
 
 		ui.Message(fmt.Sprintf("mounting %s to %s", device, mountpoint))
-		_, err := exec.Command("mount", device, mountpoint).CombinedOutput()
+		_, err := exec.Command("mount", "-o", "discard", device, mountpoint).CombinedOutput()
 		if err != nil {
 			ui.Error(err.Error())
 			return multistep.ActionHalt


### PR DESCRIPTION
This allows creating huge empty images without consuming too much space on CI systems and it heavily speeds up writing the image to sd-cards if the sparse blocks are skipped.

The discard mount also makes blocks sparse again (loop-mounts support that since while), if during work on the mounted image files/blocks are deleted. An alternative could be calling `fstrim` right before doing umount.