### PR TITLE
Add resizerootfs scripts and add to one board as example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ To execute command within chroot environment you should use chroot communicator:
  }
 ]
 ```
+For an extended example that does provisioning via script including provisioning of a resize-root-fs systemd service see [here](./boards/raspberry-pi/archlinuxarm.json).
 
 # Flashing
 To dump image on device you can use [custom postprocessor](https://github.com/mkaczanowski/packer-post-processor-flasher) (really wrapper around `dd` with some sanity checks):

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ To execute command within chroot environment you should use chroot communicator:
  }
 ]
 ```
-For an extended example that does provisioning via script including provisioning of a resize-root-fs systemd service see [here](./boards/raspberry-pi/archlinuxarm.json).
+This plugin doesn't resize partitions on the base image. However, you can easily expand partition size at the boot time with a systemd service. [Here](./boards/raspberry-pi/archlinuxarm.json) you can find real-life example, where a raspberry pi root-fs partition expands to all available space on sdcard.
 
 # Flashing
 To dump image on device you can use [custom postprocessor](https://github.com/mkaczanowski/packer-post-processor-flasher) (really wrapper around `dd` with some sanity checks):

--- a/boards/raspberry-pi/archlinuxarm.json
+++ b/boards/raspberry-pi/archlinuxarm.json
@@ -36,8 +36,22 @@
     {
       "type": "shell",
       "inline": [
-        "touch /tmp/test"
+        "pacman-key --init",
+        "pacman-key --populate archlinuxarm",
+        "mv /etc/resolv.conf /etc/resolv.conf.bk",
+        "echo 'nameserver 8.8.8.8' > /etc/resolv.conf",
+        "pacman -Sy --noconfirm --needed",
+        "pacman -S parted --noconfirm --needed"
       ]
+    },
+    {
+      "type": "file",
+      "source": "scripts/resizerootfs",
+      "destination": "/tmp"
+    },
+    {
+      "type": "shell",
+      "script": "scripts/bootstrap_resizerootfs.sh"
     }
   ]
 }

--- a/scripts/bootstrap_resizerootfs.sh
+++ b/scripts/bootstrap_resizerootfs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -o errtrace -o nounset -o pipefail -o errexit
+
+# set up one shot resize root fs for first boot
+mv /tmp/resizerootfs/resizerootfs.service /etc/systemd/system
+mv /tmp/resizerootfs/resizerootfs /usr/sbin/
+systemctl enable resizerootfs.service

--- a/scripts/resizerootfs/resizerootfs
+++ b/scripts/resizerootfs/resizerootfs
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -x
+
+roottmp=$(lsblk -l -o NAME,MOUNTPOINT | grep '/$')
+rootpart=/dev/${roottmp%% */}
+rootdev=/dev/$(echo "${roottmp}" | awk '{split($0,a,"p"); print a[1]}')
+cnt=$(echo "${rootpart}" | awk '{split($0,a,"p"); print a[2]}')
+
+flock "${rootdev}" sfdisk -f "${rootdev}" -N "${cnt}" <<EOF
+,+
+EOF
+
+sleep 5
+
+udevadm settle
+
+sleep 5
+
+flock "${rootdev}" partprobe "${rootdev}"
+
+mount -o remount,rw "${rootpart}"
+
+resize2fs "${rootpart}"
+
+exit 0

--- a/scripts/resizerootfs/resizerootfs.service
+++ b/scripts/resizerootfs/resizerootfs.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=resize root file system
+Before=local-fs-pre.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+TimeoutSec=infinity
+ExecStart=/usr/sbin/resizerootfs
+ExecStart=/bin/systemctl --no-reload disable %n
+
+[Install]
+RequiredBy=local-fs-pre.target


### PR DESCRIPTION
Following up to the discussion and information in https://github.com/mkaczanowski/packer-builder-arm/issues/19

Adding as an example as this could be helpful for almost all boards and distributions.

Tested with rpi1b here.

Pinging @bcomnes who also participated in the related discussion.