### PR TITLE
Dockerfile: add ca-certificates to final image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,7 @@ FROM ubuntu:focal
 RUN apt-get update -qq \
  && apt-get install -qqy --no-install-recommends \
   qemu-user-static \
+  ca-certificates \
   dosfstools \
   gdisk \
   kpartx \


### PR DESCRIPTION
Without this, HTTPS connections (say, to download raspbian images) fail because they can't verify certificates.

ex.:
```
1 error(s) occurred:

* couldn't extract checksum from checksum file
```