### PR TITLE
Update .dockerignore to fix build with Docker Hub Cloud Builder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,8 @@
-# Ignore everything
-**
-
-# Include only the files we need
-!/builder
-!/config
-!/docker
-!main.go
-!go.sum
-!go.mod
+.git*
+boards
+packer_cache
+scripts
+*.img
+*.img.*
+*.tar
+*.tar.*


### PR DESCRIPTION
Update .dockerignore as ignore ** + include some !directories causes issues.

This is fixed in newer Docker versions, but the Docker Hub Cloud Builder
seems to be still affected by this.

See also https://github.com/docker/compose/issues/6024