### PR TITLE
Extend Docker entrypoint.sh to support installing extra-system-packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ matrix:
           docker run --rm -i hadolint/hadolint < docker/Dockerfile;
           docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable --enable=all docker/entrypoint.sh;
           docker build -t packer-builder-arm -f docker/Dockerfile .;
-          docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build packer-builder-arm build boards/raspberry-pi/archlinuxarm.json;
+          docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build packer-builder-arm build boards/raspberry-pi/archlinuxarm.json -extra-system-packages=bmap-tools,zstd;
           du -h raspberry-pi.img;
           du -h --apparent-size raspberry-pi.img

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ This method is primarily for macOS users where is no native way to use qemu-user
 ```
 docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm build boards/raspberry-pi/raspbian.json
 ```
+More system packages (e.g. bmap-tools, zstd) can be added via the parameter `-extra-system-packages=...`:
+```
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm build boards/raspberry-pi/raspbian.json -extra-system-packages=bmap-tools,zstd
+```
+
 ### Usage via local container build:
 Build the container locally:
 ```

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,6 +6,22 @@ bash /register --reset -p yes >/dev/null 2>&1
 
 PACKER=/bin/packer
 
-echo running "${PACKER}"
+declare -a EXTRA_SYSTEM_PACKAGES=()
+for arg do
+    shift
+    if [[ "${arg}" == -extra-system-packages=* ]]; then
+        IFS=',' read -r -a EXTRA_SYSTEM_PACKAGES <<< "${arg//-extra-system-packages=}"
+        continue
+    fi
+    set -- "$@" "${arg}"
+done
+
+if [ -n "${EXTRA_SYSTEM_PACKAGES[0]}" ]; then
+    echo "Installing extra system packages: ${EXTRA_SYSTEM_PACKAGES[*]}"
+    apt-get update
+    apt-get install -y --no-install-recommends "${EXTRA_SYSTEM_PACKAGES[@]}"
+fi
+
+echo running "${PACKER}" "${@}"
 
 exec "${PACKER}" "${@}"


### PR DESCRIPTION
The docker container currently contains the bare minimum list of packages
to get an image built. By adding a parameter to the entrypoint.sh script
more packages can be installed along the way in a flexible way, without
the need to extend the provided container.

E.g. useable to add bmap-tools or zstd.