### PR TITLE
Fix Docker entrypoint when no -extra-system-packages are specified

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,7 +16,7 @@ for arg do
     set -- "$@" "${arg}"
 done
 
-if [ -n "${EXTRA_SYSTEM_PACKAGES[0]}" ]; then
+if [ "${#EXTRA_SYSTEM_PACKAGES[@]}" -gt 0 ]; then
     echo "Installing extra system packages: ${EXTRA_SYSTEM_PACKAGES[*]}"
     apt-get update
     apt-get install -y --no-install-recommends "${EXTRA_SYSTEM_PACKAGES[@]}"


### PR DESCRIPTION
Otherwise shows error:
/entrypoint.sh: line 19: EXTRA_SYSTEM_PACKAGES[0]: unbound variable

Ping @rmb938 who reported this in https://github.com/mkaczanowski/packer-builder-arm/pull/31