### PR TITLE
install psmisc for fuser

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update -qq \
   kpartx \
   libarchive-tools \
   sudo \
+  psmisc \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build


### PR DESCRIPTION
Without this the following error appears at the end of the packer build

```
==> arm: optional `fuser -k` failed with exec: "fuser": executable file not found in $PATH:
```

With the fix the following is printed at the end of the build

```
==> arm: optional `fuser -k` failed with exit status 1:
```
