### PR TITLE
Add qemu-utils + parted, needed for resize mode to work in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,10 +34,12 @@ FROM ubuntu:focal
 RUN apt-get update -qq \
  && apt-get install -qqy --no-install-recommends \
   qemu-user-static \
+  qemu-utils \
   ca-certificates \
   dosfstools \
   gdisk \
   kpartx \
+  parted \
   libarchive-tools \
   sudo \
   psmisc \


### PR DESCRIPTION
Hello! Great work with this plugin, very useful 🙏 

I have been using the Docker image since I'm on a Mac.  Today I tried resize mode and it fails because it tries to call `qemu-img` and `parted`, so I added them to the Dockerfile and it worked.

While I'm here, haven't looked at the go code yet, is there a way to not use a cached downloaded zip, and instead an already expanded local image file to start?  There is significant time spent unzipping and redundant installs, I'm looking to speed my workflow up here.  I tried `file://`, it mostly works (I think), but I also think it's wasting time with the checksum.