### PR TITLE
Adds RaspberryPi OS 64bits (beta) lite version to the boards

### DIFF
--- a/.github/workflows/all-boards.yml
+++ b/.github/workflows/all-boards.yml
@@ -20,6 +20,7 @@ jobs:
           - raspberry-pi/raspbian.json
           - raspberry-pi/raspbian-resize.json
           - raspberry-pi-3/archlinuxarm.json
+          - raspberry-pi-3/raspios-lite-arm64.json
           - raspberry-pi-4/ubuntu_server_20.04_arm64.json
           - raspberry-pi-4/archlinuxarm.json
           - wandboard/archlinuxarm.json

--- a/boards/raspberry-pi-3/raspios-lite-arm64.json
+++ b/boards/raspberry-pi-3/raspios-lite-arm64.json
@@ -1,0 +1,43 @@
+{
+  "variables": {},
+  "builders": [{
+    "type": "arm",
+    "file_urls" : ["https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2020-08-24/2020-08-20-raspios-buster-arm64-lite.zip"],
+    "file_checksum_url": "https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2020-08-24/2020-08-20-raspios-buster-arm64-lite.zip.sha256",
+    "file_checksum_type": "sha256",
+    "file_target_extension": "zip",
+    "image_build_method": "reuse",
+    "image_path": "raspios-arm64.img",
+    "image_size": "2G",
+    "image_type": "dos",
+    "image_partitions": [
+      {
+        "name": "boot",
+        "type": "c",
+        "start_sector": "8192",
+        "filesystem": "vfat",
+        "size": "256M",
+        "mountpoint": "/boot"
+      },
+      {
+        "name": "root",
+        "type": "83",
+        "start_sector": "532480",
+        "filesystem": "ext4",
+        "size": "0",
+        "mountpoint": "/"
+      }
+    ],
+    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"],
+    "qemu_binary_source_path": "/usr/bin/qemu-aarch64-static",
+    "qemu_binary_destination_path": "/usr/bin/qemu-aarch64-static"
+  }],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "touch /tmp/test"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
RaspberryPi Foundation is releasing 64bits version of their OS. 
The news is here: https://www.raspberrypi.org/forums/viewtopic.php?f=117&t=275370

The lite 64bits image (probably more suitable for custom builds) is fetched from here: https://downloads.raspberrypi.org/raspios_lite_arm64/images/raspios_lite_arm64-2020-08-24/