### PR TITLE
Fuxes build fail for RPi3 archlinuxarm image

### DIFF
--- a/boards/raspberry-pi-3/archlinuxarm.json
+++ b/boards/raspberry-pi-3/archlinuxarm.json
@@ -2,8 +2,8 @@
   "variables": {},
   "builders": [{
     "type": "arm",
-    "file_urls" : ["http://os.archlinuxarm.org/os/ArchLinuxARM-rpi-3-latest.tar.gz"],
-    "file_checksum_url": "http://os.archlinuxarm.org/os/ArchLinuxARM-rpi-3-latest.tar.gz.md5",
+    "file_urls" : ["http://os.archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz"],
+    "file_checksum_url": "http://os.archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz.md5",
     "file_checksum_type": "md5",
     "file_unarchive_cmd": ["bsdtar", "-xpf", "$ARCHIVE_PATH", "-C", "$MOUNTPOINT"],
     "file_target_extension": "tar.gz",

--- a/boards/raspberry-pi-3/archlinuxarm.json
+++ b/boards/raspberry-pi-3/archlinuxarm.json
@@ -2,8 +2,8 @@
   "variables": {},
   "builders": [{
     "type": "arm",
-    "file_urls" : ["http://os.archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz"],
-    "file_checksum_url": "http://os.archlinuxarm.org/os/ArchLinuxARM-rpi-2-latest.tar.gz.md5",
+    "file_urls" : ["http://os.archlinuxarm.org/os/ArchLinuxARM-rpi-aarch64-latest.tar.gz"],
+    "file_checksum_url": "http://os.archlinuxarm.org/os/ArchLinuxARM-rpi-aarch64-latest.tar.gz.md5",
     "file_checksum_type": "md5",
     "file_unarchive_cmd": ["bsdtar", "-xpf", "$ARCHIVE_PATH", "-C", "$MOUNTPOINT"],
     "file_target_extension": "tar.gz",


### PR DESCRIPTION
According to [ArchlinuxARM documentation for the RaspberryPi 3](https://archlinuxarm.org/platforms/armv8/broadcom/raspberry-pi-3), one should either use RPi2 image or aarch64 image. 

In this case, I choose the aarch64 image since the qemu kernel is also using that architecture