### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ cd packer-builder-arm
 vagrant up
 vagrant provision
 ```
+> Note: For this the disksize plugin is needed if not already installed `vagrant plugin install vagrant-disksize`
 
 # Demo
 [![asciicast](https://asciinema.org/a/7ad1nm2Q7DRFVlHpqAknPolNo.svg)](https://asciinema.org/a/7ad1nm2Q7DRFVlHpqAknPolNo)


### PR DESCRIPTION
Added mention of vagrant-disksize dependency.
Without installing this plugin the vagrant instance is not building properly.

See #57 - I could not confirm fix in my env so running it inside vagrant machine lead to successful build.
While running vagrant up it lead to the following error:
```
Vagrant:
* Unknown configuration section 'disksize'.
```

By installing the disksize plugin via `vagrant plugin install vagrant-disksize` this was solved.
