### PR TITLE
Add image_mount_path to hcl spec

### DIFF
--- a/builder/builder.hcl2spec.go
+++ b/builder/builder.hcl2spec.go
@@ -20,6 +20,7 @@ type FlatConfig struct {
 	ImagePath                 *string                  `mapstructure:"image_path" required:"true" cty:"image_path"`
 	ImageSize                 *string                  `mapstructure:"image_size" cty:"image_size"`
 	ImageType                 *string                  `mapstructure:"image_type" cty:"image_type"`
+	ImageMountPath            *string                  `mapstructure:"image_mount_path" cty:"image_mount_path"`
 	ImageBuildMethod          *string                  `mapstructure:"image_build_method" cty:"image_build_method"`
 	ImageSizeBytes            *uint64                  `mapstructure:"image_size_bytes" cty:"image_size_bytes"`
 	ImagePartitions           []config.FlatPartition   `mapstructure:"image_partitions" cty:"image_partitions"`
@@ -50,6 +51,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"file_target_path":             &hcldec.AttrSpec{Name: "file_target_path", Type: cty.String, Required: false},
 		"file_target_extension":        &hcldec.AttrSpec{Name: "file_target_extension", Type: cty.String, Required: false},
 		"image_path":                   &hcldec.AttrSpec{Name: "image_path", Type: cty.String, Required: false},
+		"image_mount_path":             &hcldec.AttrSpec{Name: "image_mount_path", Type: cty.String, Required: false},
 		"image_size":                   &hcldec.AttrSpec{Name: "image_size", Type: cty.String, Required: false},
 		"image_type":                   &hcldec.AttrSpec{Name: "image_type", Type: cty.String, Required: false},
 		"image_build_method":           &hcldec.AttrSpec{Name: "image_build_method", Type: cty.String, Required: false},


### PR DESCRIPTION
With the following `provisioner/packer_arm.pkr.hcl` file

```
locals {
  image_mount_path = "/tmp/packer_mount_dir"
}

source "arm" "provisioner" {
  file_urls = [
    "http://cdimage.ubuntu.com/releases/20.04.1/release/ubuntu-20.04.1-preinstalled-server-arm64+raspi.img.xz"
  ]
  file_checksum_url = "http://cdimage.ubuntu.com/releases/20.04.1/release/SHA256SUMS"
  file_checksum_type = "sha256"
  file_target_extension = "xz"
  file_unarchive_cmd = ["xz", "--decompress", "$ARCHIVE_PATH"]
  image_build_method = "reuse"
  image_path = "ubuntu-20.04.img"
  image_size = "3.1G"
  image_mount_path = local.image_mount_path
  image_type = "dos"

  image_partitions {
    name = "boot"
    type = "c"
    start_sector = 2048
    filesystem = "fat"
    size = "256M"
    mountpoint = "/boot/firmware"
  }

  image_partitions {
    name = "root"
    type = "83"
    start_sector = 526336
    filesystem = "ext4"
    size = "2.8G"
    mountpoint = "/"
  }

  image_chroot_env = [
    "PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
  ]

  qemu_binary_source_path = "/usr/bin/qemu-aarch64-static"
  qemu_binary_destination_path = "/usr/bin/qemu-aarch64-static"
}

build {
  sources = ["source.arm.provisioner"]

  # we have to replace the existing resolv.conf because it relies on systemd-resolved
  # which is not running when we chroot into the image.
  provisioner "shell" {
    inline = [
      "mv -v /etc/resolv.conf /etc/resolv.conf.orig",
      "echo 'nameserver 8.8.8.8' > /etc/resolv.conf",
    ]
  }

  provisioner "ansible" {
    playbook_file = "./playbook.yml"
    extra_arguments = [
      "--connection=chroot",
      "--extra-vars=architecture=arm64",
      "--inventory-file=${local.image_mount_path}",
    ]
  }

  # Restore the temporary resolv.conf with the one from systemd-resolved
  provisioner "shell" {
    inline = [
      "rm -v /etc/resolv.conf",
      "mv -v /etc/resolv.conf.orig /etc/resolv.conf",
    ]
  }
}
```

I got an error using the `image_mount_path`:

```
An argument named "image_mount_path" is not expected here.
```

I've updated the hcl spec **manually** (no clue how to generate it 😅) and now it seems to start the build. 

