### PR TITLE
Bump Ubuntu Server from 20.04.1 to 20.04.2 for PI-4

### DIFF
--- a/boards/raspberry-pi-4/ubuntu_server_20.04_arm64.json
+++ b/boards/raspberry-pi-4/ubuntu_server_20.04_arm64.json
@@ -2,8 +2,8 @@
   "variables": {},
   "builders": [{
     "type": "arm",
-    "file_urls" : ["http://cdimage.ubuntu.com/releases/20.04.1/release/ubuntu-20.04.1-preinstalled-server-arm64+raspi.img.xz"],
-    "file_checksum_url": "http://cdimage.ubuntu.com/releases/20.04.1/release/SHA256SUMS",
+    "file_urls" : ["http://cdimage.ubuntu.com/releases/20.04.1/release/ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz"],
+    "file_checksum_url": "http://cdimage.ubuntu.com/releases/20.04.2/release/SHA256SUMS",
     "file_checksum_type": "sha256",
     "file_target_extension": "xz",
     "file_unarchive_cmd": ["xz", "--decompress", "$ARCHIVE_PATH"],


### PR DESCRIPTION
This PR simply bumps the version of the base image and the checksum file URL to the latest release by Ubuntu. 

It seems that with the release of 20.04.**2**, the checksum file at the specified [URL](http://cdimage.ubuntu.com/releases/20.04.1/release/SHA256SUMS) no longer contains checksums for 20.04.**1**. This causes `packer build` command to fail with the following error message:

```
Error: Failed to prepare build: "arm"
1 error(s) occurred:
* couldn't extract checksum from checksum file
 ```