### PR TITLE
Feature : Adds ability to chose tmp directory location

### DIFF
--- a/builder/builder.hcl2spec.go
+++ b/builder/builder.hcl2spec.go
@@ -17,6 +17,7 @@ type FlatConfig struct {
 	FileUnarchiveCmd          []string                 `mapstructure:"file_unarchive_cmd" cty:"file_unarchive_cmd"`
 	TargetPath                *string                  `mapstructure:"file_target_path" cty:"file_target_path"`
 	TargetExtension           *string                  `mapstructure:"file_target_extension" cty:"file_target_extension"`
+	TmpDirLocation            *string                  `mapstructure:"file_tmp_dir_location" cty:"file_tmp_dir_location"`
 	ImagePath                 *string                  `mapstructure:"image_path" required:"true" cty:"image_path"`
 	ImageSize                 *string                  `mapstructure:"image_size" cty:"image_size"`
 	ImageType                 *string                  `mapstructure:"image_type" cty:"image_type"`
@@ -51,6 +52,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"file_unarchive_cmd":           &hcldec.AttrSpec{Name: "file_unarchive_cmd", Type: cty.List(cty.String), Required: false},
 		"file_target_path":             &hcldec.AttrSpec{Name: "file_target_path", Type: cty.String, Required: false},
 		"file_target_extension":        &hcldec.AttrSpec{Name: "file_target_extension", Type: cty.String, Required: false},
+		"file_tmp_dir_location":        &hcldec.AttrSpec{Name: "file_tmp_dir_location", Type: cty.String, Required: false},
 		"image_path":                   &hcldec.AttrSpec{Name: "image_path", Type: cty.String, Required: false},
 		"image_size":                   &hcldec.AttrSpec{Name: "image_size", Type: cty.String, Required: false},
 		"image_type":                   &hcldec.AttrSpec{Name: "image_type", Type: cty.String, Required: false},

--- a/builder/step_extract_and_copy_image.go
+++ b/builder/step_extract_and_copy_image.go
@@ -28,7 +28,7 @@ func (s *StepExtractAndCopyImage) Run(ctx context.Context, state multistep.State
 	var out []byte
 
 	// step 1: create temporary dir
-	dir, err := ioutil.TempDir("", "image")
+	dir, err := ioutil.TempDir(config.TmpDirLocation, "image")
 	if err != nil {
 		ui.Error(fmt.Sprintf("error while creating temporary directory %v", err))
 		return multistep.ActionHalt
@@ -44,41 +44,41 @@ func (s *StepExtractAndCopyImage) Run(ctx context.Context, state multistep.State
 	}
 
 	// skip unarchive logic if provided raw image (steps: 3&4)
-	if(config.RemoteFileConfig.TargetExtension == "img" || config.RemoteFileConfig.TargetExtension == "iso") {
-        ui.Message("using raw image")
-    } else {
-        // step 3: unarchive file within temporary dir
-        ui.Message(fmt.Sprintf("unpacking %s to %s", archivePath, config.ImageConfig.ImagePath))
-        if len(config.RemoteFileConfig.FileUnarchiveCmd) != 0 {
-            cmd := make([]string, len(config.RemoteFileConfig.FileUnarchiveCmd))
-            vars := map[string]string{
-                "$ARCHIVE_PATH": dst,
-                "$TMP_DIR":      dir,
-            }
-    
-            for i, elem := range config.RemoteFileConfig.FileUnarchiveCmd {
-                if _, ok := vars[elem]; ok {
-                    cmd[i] = vars[elem]
-                } else {
-                    cmd[i] = elem
-                }
-            }
-    
-            ui.Message(fmt.Sprintf("unpacking with custom comand: %s", cmd))
-            out, err = exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
-        } else {
-            out, err = []byte("N/A"), archiver.Unarchive(archivePath, dir)
-        }
-    
-        if err != nil {
-            ui.Error(fmt.Sprintf("error while unpacking %v: %s", err, out))
-            return multistep.ActionHalt
-        }
-    
-        // step 4: if previously copied archive still exists, lets remove it
-        if _, err := os.Stat(dst); err == nil {
-            os.RemoveAll(dst)
-        }
+	if config.RemoteFileConfig.TargetExtension == "img" || config.RemoteFileConfig.TargetExtension == "iso" {
+		ui.Message("using raw image")
+	} else {
+		// step 3: unarchive file within temporary dir
+		ui.Message(fmt.Sprintf("unpacking %s to %s", archivePath, config.ImageConfig.ImagePath))
+		if len(config.RemoteFileConfig.FileUnarchiveCmd) != 0 {
+			cmd := make([]string, len(config.RemoteFileConfig.FileUnarchiveCmd))
+			vars := map[string]string{
+				"$ARCHIVE_PATH": dst,
+				"$TMP_DIR":      dir,
+			}
+
+			for i, elem := range config.RemoteFileConfig.FileUnarchiveCmd {
+				if _, ok := vars[elem]; ok {
+					cmd[i] = vars[elem]
+				} else {
+					cmd[i] = elem
+				}
+			}
+
+			ui.Message(fmt.Sprintf("unpacking with custom comand: %s", cmd))
+			out, err = exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
+		} else {
+			out, err = []byte("N/A"), archiver.Unarchive(archivePath, dir)
+		}
+
+		if err != nil {
+			ui.Error(fmt.Sprintf("error while unpacking %v: %s", err, out))
+			return multistep.ActionHalt
+		}
+
+		// step 4: if previously copied archive still exists, lets remove it
+		if _, err := os.Stat(dst); err == nil {
+			os.RemoveAll(dst)
+		}
 	}
 
 	// step 5: we expect only one file in the directory

--- a/config/remote_file_config.go
+++ b/config/remote_file_config.go
@@ -25,6 +25,7 @@ type RemoteFileConfig struct {
 	FileUnarchiveCmd []string `mapstructure:"file_unarchive_cmd"`
 	TargetPath       string   `mapstructure:"file_target_path"`
 	TargetExtension  string   `mapstructure:"file_target_extension"`
+	TmpDirLocation   string   `mapstructure:"file_tmp_dir_location"`
 }
 
 // Prepare remote file config

--- a/config/remote_file_config.hcl2spec.go
+++ b/config/remote_file_config.hcl2spec.go
@@ -16,6 +16,7 @@ type FlatRemoteFileConfig struct {
 	FileUnarchiveCmd []string `mapstructure:"file_unarchive_cmd" cty:"file_unarchive_cmd"`
 	TargetPath       *string  `mapstructure:"file_target_path" cty:"file_target_path"`
 	TargetExtension  *string  `mapstructure:"file_target_extension" cty:"file_target_extension"`
+	TmpDirLocation   *string  `mapstructure:"file_tmp_dir_location" cty:"file_tmp_dir_location"`
 }
 
 // FlatMapstructure returns a new FlatRemoteFileConfig.
@@ -37,6 +38,7 @@ func (*FlatRemoteFileConfig) HCL2Spec() map[string]hcldec.Spec {
 		"file_unarchive_cmd":    &hcldec.AttrSpec{Name: "file_unarchive_cmd", Type: cty.List(cty.String), Required: false},
 		"file_target_path":      &hcldec.AttrSpec{Name: "file_target_path", Type: cty.String, Required: false},
 		"file_target_extension": &hcldec.AttrSpec{Name: "file_target_extension", Type: cty.String, Required: false},
+		"file_tmp_dir_location": &hcldec.AttrSpec{Name: "file_tmp_dir_location", Type: cty.String, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
It happened to me that the `/tmp` directory on my computer did not have enough available space when unpacking the initial image, so I added the option to chose another place to do it : `file_tmp_dir_location`. The behavior is the folowing:
- If it is unset or set to `""`, it defaults to `/tmp`;
- If it is set, then it will use the value as the base path.