### PR TITLE
Support building the Docker Container for aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
         - docker
       script:
         - set -o errexit;
-          docker run --rm -i hadolint/hadolint < docker/Dockerfile;
+          docker run --rm -i ghcr.io/hadolint/hadolint < docker/Dockerfile;
           docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable --enable=all docker/entrypoint.sh;
           docker build -t packer-builder-arm -f docker/Dockerfile .;
           docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build packer-builder-arm build boards/raspberry-pi/archlinuxarm.json -extra-system-packages=bmap-tools,zstd;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN go build -o packer-builder-arm
 ENV PACKER_VERSION 1.5.5
 
 RUN if [ "$(uname -m)" = "aarch64" ]; then PACKER_ARCH="arm64"; else PACKER_ARCH="amd64"; fi && \
-  wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${PACKER_ARCH}.zip -O /tmp/packer.zip && \
+  wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${PACKER_ARCH}.zip -q -O /tmp/packer.zip && \
   unzip /tmp/packer.zip -d /bin && \
   rm /tmp/packer.zip
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,8 @@ RUN go build -o packer-builder-arm
 
 ENV PACKER_VERSION 1.5.5
 
-RUN wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip -O /tmp/packer.zip && \
+RUN if [ "$(uname -m)" = "aarch64" ]; then PACKER_ARCH="arm64"; else PACKER_ARCH="amd64"; fi && \
+  wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${PACKER_ARCH}.zip -O /tmp/packer.zip && \
   unzip /tmp/packer.zip -d /bin && \
   rm /tmp/packer.zip
 


### PR DESCRIPTION
aarch64 containers also run pretty good on Apple M1 hardware.

Also get hadolint from ghrc.io (GitHub container registry) instead of Docker Hub to avoid pull rate limitations.

This is just the first step, the qemu stuff does not work on aarch64 and requires to be updated/deactivated in further commits.