### PR TITLE
Enable building on Linux/Mac arm64 with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ More system packages (e.g. bmap-tools, zstd) can be added via the parameter `-ex
 docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm build boards/raspberry-pi/raspbian.json -extra-system-packages=bmap-tools,zstd
 ```
 
-### Usage via local container build:
+### Usage via local container build (supports amd64/aarch64 hosts):
 Build the container locally:
 ```
 docker build -t packer-builder-arm -f docker/Dockerfile .

--- a/builder/step_chroot_provision.go
+++ b/builder/step_chroot_provision.go
@@ -14,6 +14,7 @@ import (
 type StepChrootProvision struct {
 	ImageMountPointKey string
 	Hook               packer.Hook
+	SetupQemu          bool
 }
 
 // Run the step
@@ -25,11 +26,18 @@ func (s *StepChrootProvision) Run(ctx context.Context, state multistep.StateBag)
 	comm := &chroot.Communicator{
 		Chroot: imageMountpoint,
 		CmdWrapper: func(cmd string) (string, error) {
-			return fmt.Sprintf(
-				"%s %s",
-				strings.Join(config.ImageConfig.ImageChrootEnv, " "),
-				cmd,
-			), nil
+			if s.SetupQemu {
+				return fmt.Sprintf(
+					"%s %s",
+					strings.Join(config.ImageConfig.ImageChrootEnv, " "),
+					cmd,
+				), nil
+			} else {
+				return fmt.Sprintf(
+					"%s",
+					cmd,
+				), nil
+			}
 		},
 	}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM multiarch/qemu-user-static:register AS register
+FROM tonistiigi/binfmt:qemu-v5.0.1 AS binfmt
 FROM golang:buster AS builder
 
 # hadolint ignore=DL3008
@@ -34,8 +34,6 @@ FROM ubuntu:focal
 # hadolint ignore=DL3008
 RUN apt-get update -qq \
  && apt-get install -qqy --no-install-recommends \
-  qemu-user-static \
-  qemu-utils \
   ca-certificates \
   dosfstools \
   gdisk \
@@ -51,7 +49,6 @@ WORKDIR /build
 
 COPY docker/entrypoint.sh /entrypoint.sh
 COPY --from=builder /build/packer-builder-arm /bin/packer /bin/
-COPY --from=register /register /register
-COPY --from=register /qemu-binfmt-conf.sh /qemu-binfmt-conf.sh
+COPY --from=binfmt /usr/bin/ /usr/bin
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -o errtrace -o nounset -o pipefail -o errexit
 
-bash /register --reset -p yes >/dev/null 2>&1
+/usr/bin/binfmt --install all >/dev/null 2>&1
 
 PACKER=/bin/packer
 
@@ -21,6 +21,8 @@ if [ "${#EXTRA_SYSTEM_PACKAGES[@]}" -gt 0 ]; then
     apt-get update
     apt-get install -y --no-install-recommends "${EXTRA_SYSTEM_PACKAGES[@]}"
 fi
+
+export DONT_SETUP_QEMU=1
 
 echo running "${PACKER}" "${@}"
 


### PR DESCRIPTION
tonistiigi/binfmt is a drop in replacement for multiarch/qemu-user-static, which not only can emulate arm/arm64 on amd64 but also on arm64 and other architectures. By setting up qemu with Docker can automatically execute the binaries of other achitecture in the chroot without any additional setup.

This way the Docker Container can now be created for amd64 and aarch64. The aarch64 version also works on Linux aarch64 including Docker on Apple M1 hardware.

fixes https://github.com/mkaczanowski/packer-builder-arm/issues/76

Next step would be writing a Github action with buildx that builds and uploads a Docker multi-arch Docker image.