### PR TITLE
Build + Upload multi-arch docker image via Github actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,48 @@
+name: Docker Build and Upload
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    environment:
+      name: docker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/master'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # - name: Login to GitHub Container Registry
+      #   uses: docker/login-action@v1
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.repository_owner }}
+      #     password: ${{ secrets.GHCR_IO_REGISTRY_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: github.ref == 'refs/heads/master'
+          tags: |
+            ${{ github.repository_owner }}/packer-builder-arm:latest
+          # ghcr.io/${{ github.repository_owner }}/packer-builder-arm:latest


### PR DESCRIPTION
The ci/dockercloud builder does currently not support buildx multiarch building... There are several open tickets and people tried all kind of tricks via hooks, but none of those work.

Via Github actions this is all easily possible and enables building and uploading multi-arch images.

This requires deactivating the ci/dockercloud builder and adding a Docker Hub user + created token to the repo secrets via an environment (named `docker`) restricted to the master branch.

(The commented lines also show how to additional upload to the Github container registry ghcr.io, which has no pull rate-limitation, but requires another upload token to be added via secrets).