### PR TITLE
Add build configuration that automatically installs Docker

### DIFF
--- a/boards/raspberry-pi-4/docker-ubuntu_server_20.04_arm64.json
+++ b/boards/raspberry-pi-4/docker-ubuntu_server_20.04_arm64.json
@@ -1,0 +1,53 @@
+{
+  "variables": {},
+  "builders": [{
+    "type": "arm",
+    "file_urls" : ["http://cdimage.ubuntu.com/releases/20.04.2/release/ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz"],
+    "file_checksum_url": "http://cdimage.ubuntu.com/releases/20.04.2/release/SHA256SUMS",
+    "file_checksum_type": "sha256",
+    "file_target_extension": "xz",
+    "file_unarchive_cmd": ["xz", "--decompress", "$ARCHIVE_PATH"],
+    "image_build_method": "reuse",
+    "image_path": "ubuntu-20.04.img",
+    "image_size": "3.1G",
+    "image_type": "dos",
+    "image_partitions": [
+      {
+        "name": "boot",
+        "type": "c",
+        "start_sector": "2048",
+        "filesystem": "fat",
+        "size": "256M",
+        "mountpoint": "/boot/firmware"
+      },
+      {
+        "name": "root",
+        "type": "83",
+        "start_sector": "526336",
+        "filesystem": "ext4",
+        "size": "2.8G",
+        "mountpoint": "/"
+      }
+
+    ],
+    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"],
+    "qemu_binary_source_path": "/usr/bin/qemu-aarch64-static",
+    "qemu_binary_destination_path": "/usr/bin/qemu-aarch64-static"
+  }],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "mv /etc/resolv.conf /etc/resolv.conf.bk",
+        "echo 'nameserver 8.8.8.8' > /etc/resolv.conf",
+        "apt-get update -y",
+        "apt-get install -y apt-transport-https ca-certificates gnupg lsb-release",
+        "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg",
+        "echo \"deb [arch=arm64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable\" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null",
+        "sudo apt-get update -y",
+        "sudo apt-get install -y docker-ce docker-ce-cli containerd.io"
+      ]
+    }
+  ],
+  "post-processors": []
+}


### PR DESCRIPTION
Don't want to add too many build configurations but docker seems to be a common need

Impacted by  https://github.com/mkaczanowski/packer-builder-arm/issues/83 though and requires the `mv /etc/resolv.conf` workaround


Signed-off-by: Dax McDonald <31839142+daxmc99@users.noreply.github.com>
