### PR TITLE
Set push: true to really push the docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,8 +11,6 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    environment:
-      name: docker
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,7 +25,6 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: github.ref == 'refs/heads/master'
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -45,6 +42,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
+          push: true
           tags: |
             ${{ github.repository_owner }}/packer-builder-arm:latest
           # ghcr.io/${{ github.repository_owner }}/packer-builder-arm:latest


### PR DESCRIPTION
Also:
* remove not required if master login conditional.
* remove environment name specification, as secrets seem to be accessible without (seen that in the other workflows). Is that correct?

Without `push: true` the following message is show during the action run:

time="2021-04-20T18:59:19Z" level=warning msg="No output specified for docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load"

Also looking at the green tick on master branch: it seems that the Docker Hub Builder is still triggered and building.