### PR TITLE
Restrict armv{7,8} docker workflows to master branch

### DIFF
--- a/.github/workflows/archlinuxarm-armv7-docker.yml
+++ b/.github/workflows/archlinuxarm-armv7-docker.yml
@@ -1,6 +1,7 @@
 name: Archlinuxarm armv7 docker
 on:
   push:
+    branches: [ master ]
   schedule:
     # once a week
     - cron:  '0 0 * * 1'

--- a/.github/workflows/archlinuxarm-armv8-docker.yml
+++ b/.github/workflows/archlinuxarm-armv8-docker.yml
@@ -1,6 +1,7 @@
 name: Archlinuxarm armv8 docker
 on:
   push:
+    branches: [ master ]
   schedule:
     # once a week
     - cron:  '0 0 * * 1'


### PR DESCRIPTION
Both workflows are normally not triggered, if PRs come from forks. If a PR comes from an internal branch (no fork, like from the Github dependapot service, see other open PR https://github.com/mkaczanowski/packer-builder-arm/pull/84) those two pipelines fail, as they do not have access to secrets. Pushing from a non-master branch anyway seems to be not desirable.