### PR TITLE
Extend dependabot to update Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     directory: "/docker"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
See also https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot