### PR TITLE
Add docker push hook to stop Docker ci/dockercloud-stage from pushing

### DIFF
--- a/docker/hooks/push
+++ b/docker/hooks/push
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "Not pushing."


### PR DESCRIPTION
Checking the status tick on latest commit on master tells, that the Docker ci/dockercloud-stage builder is still building and pushing the linux/amd64 image and thus overwriting the multiarch linux/arm64 + linux/amd64 image+manifest pushed by the Github buildx action, which often pushes a bit earlier and thus gets overwritten: https://hub.docker.com/r/mkaczanowski/packer-builder-arm/tags?page=1&ordering=last_updated

Using a hook in the repo pushing by the Docker ci/dockercloud-stage builder can be avoided, by overwriting the the default push command to do nothing: https://docs.docker.com/docker-hub/builds/advanced/