### PR TITLE
Run pre-installed shellcheck on travis instead of the Dockerhub version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 matrix:
   include:
     - language: go
@@ -9,7 +10,7 @@ matrix:
       script:
         - set -o errexit;
           docker run --rm -i ghcr.io/hadolint/hadolint < docker/Dockerfile;
-          docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable --enable=all docker/entrypoint.sh;
+          shellcheck --enable=all docker/entrypoint.sh;
           docker build -t packer-builder-arm -f docker/Dockerfile .;
           docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build packer-builder-arm build boards/raspberry-pi/archlinuxarm.json -extra-system-packages=bmap-tools,zstd;
           du -h raspberry-pi.img;


### PR DESCRIPTION
The Dockerhub version causes rate-limited related failures.

Also switching to Ubuntu focal (20.04) on travis (instead of the default Ubuntu Xenial 16.04) to have newer shellcheck >=0.7.0 available.