### PR TITLE
Increase docker entrypoint verbosity for better debugging

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,9 @@
 
 set -o errtrace -o nounset -o pipefail -o errexit
 
-/usr/bin/binfmt --install all >/dev/null 2>&1
+echo "uname -a: " $(uname -a)
+
+/usr/bin/binfmt --install all
 
 PACKER=/bin/packer
 


### PR DESCRIPTION
The Docker container can be used on linux-{amd64, aarch64} and macOS intel/apple silicon (M1). Printing the uname output helps to understand what underlying architecture is used.

Also not hiding the binfmt install out helps to understand what is wrong in cases where that command fails.