### PR TITLE
Fix qemu error on ARM64 builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM tonistiigi/binfmt:qemu-v6.0.0 AS binfmt
-FROM public.ecr.aws/bitnami/golang:1.16-debian-10 AS builder
+FROM golang:1.16-buster AS builder
 
 # hadolint ignore=DL3008
 RUN apt-get update -qq \


### PR DESCRIPTION
It appears that the bitnami golang image is only distributed for the `linux/amd64` platform. This means that while `packer-builder-arm` builds for `linux/arm64` will succeed, the packer binary throws an error:

```
$ docker run --rm --privileged --platform linux/arm64 -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm build boards/raspberry-pi/raspbian.json

uname -a:  Linux 71aaac6d94db 5.10.25-linuxkit #1 SMP PREEMPT Tue Mar 23 09:24:45 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
{
  "supported": [
    "linux/arm64",
    "linux/amd64",
    "linux/riscv64",
    "linux/ppc64le",
    "linux/s390x",
    "linux/386",
    "linux/mips64le",
    "linux/mips64",
    "linux/arm/v7",
    "linux/arm/v6"
  ],
  "emulators": [
    "qemu-arm",
    "qemu-i386",
    "qemu-mips64",
    "qemu-mips64el",
    "qemu-ppc64le",
    "qemu-riscv64",
    "qemu-s390x",
    "qemu-x86_64"
  ]
}
running /bin/packer build boards/raspberry-pi/raspbian.json
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```

I'm running MacOS on an M1 machine with Docker Desktop. I was able to reproduce this with a local image build as well.

Basing off of the official `golang` image (which is distributed for `linux/arm64`) fixes the issue.

(I know this was already changed in https://github.com/mkaczanowski/packer-builder-arm/commit/ba287258783f0568b41c8c335b3d151ec362d768 - maybe there's an alternative way to fix this that I'm not thinking of?)