### PR TITLE
First stab for fixing resolv.conf in issue #144

### DIFF
--- a/builder/step_setup_chroot.go
+++ b/builder/step_setup_chroot.go
@@ -1,8 +1,12 @@
 package builder
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -65,6 +69,58 @@ func getMounts() (map[string]bool, error) {
 	return selected, nil
 }
 
+// renameAndCheck courtesy of https://stackoverflow.com/a/25940392/51016
+func renameAndCheck(src, dst string) error {
+    err := os.Link(src, dst)
+    if err != nil {
+        return err
+    }
+    return os.Remove(src)
+}
+ 
+// deepCompare courtesy of https://stackoverflow.com/a/30038571/51016
+const chunkSize = 64000
+
+func deepCompare(file1, file2 string) (bool, error) {
+    // Check file size ...
+    f1, err := os.Open(file1)
+    if err != nil {
+        return false, err
+    }
+    defer f1.Close()
+
+    f2, err := os.Open(file2)
+    if err != nil {
+        return false, err
+    }
+    defer f2.Close()
+
+    for {
+        b1 := make([]byte, chunkSize)
+        _, err1 := f1.Read(b1)
+
+        b2 := make([]byte, chunkSize)
+        _, err2 := f2.Read(b2)
+
+        if err1 != nil || err2 != nil {
+            if err1 == io.EOF && err2 == io.EOF {
+                return true, nil
+            } else if err1 == io.EOF || err2 == io.EOF {
+                return false, nil
+            } else {
+				err := fmt.Errorf("file1: %w", err1)
+				err = fmt.Errorf("file2: %w", err2)
+				err = fmt.Errorf("error comparing files; %w", err)
+                return false, err
+            }
+        }
+
+        if !bytes.Equal(b1, b2) {
+            return false, nil
+        }
+    }
+}
+
 // StepSetupChroot prepares chroot environment by mounting specific locations (/dev /proc etc.)
 type StepSetupChroot struct {
 	ImageMountPointKey string
@@ -93,6 +149,47 @@ func (s *StepSetupChroot) Run(ctx context.Context, state multistep.StateBag) mul
 			ui.Error(fmt.Sprintf("error while mounting %v: %s", err, out))
 			return multistep.ActionHalt
 		}
+	}
+
+	ui.Message("patching file system for the chroot execution")
+
+	src := "/etc/resolv.conf"
+	dst := filepath.Join(imageMountpoint, src)
+	bak := dst + ".bak"
+
+	// backup the /etc/resolv.conf if it exists
+	err := renameAndCheck(dst, bak)
+	if err == nil {
+		ui.Message(fmt.Sprintf("backed up '%s' to '%s'", dst, bak))
+	} else if errors.Is(err, fs.ErrNotExist) {
+		ui.Message(fmt.Sprintf("'%s' does not exist: %v", src, err))
+	} else if errors.Is(err, fs.ErrExist) {
+		ui.Error(fmt.Sprintf("'%s' already exists: %v", dst, err))
+	} else if errors.Is(err, fs.ErrPermission) {
+		ui.Error(fmt.Sprintf("could not create '%s': %v", bak, err))
+	}
+
+	source, err := os.Open(src)
+	if err != nil {
+		ui.Error(fmt.Sprintf("error while opening source: %v: '%s'", err, src))
+		return multistep.ActionHalt
+	}
+	defer source.Close()
+
+	// Should we backup the /etc/resolv.conf if it exist and restore it before creating the final image?
+	destination, err := os.Create(dst)
+	if err != nil {
+		ui.Error(fmt.Sprintf("error while creating destination: %v: '%s'", err, dst))
+		return multistep.ActionHalt
+	}
+	defer destination.Close()
+
+	_, err = io.Copy(destination, source)
+	if err == nil {
+		ui.Message(fmt.Sprintf("copied file from '%s' to '%s'", src, dst))
+	} else {
+		ui.Error(fmt.Sprintf("error while copying: %v: from '%s' to '%s'", err, src, dst))
+		return multistep.ActionHalt
 	}
 
 	return multistep.ActionContinue
@@ -139,6 +236,32 @@ func (s *StepSetupChroot) Cleanup(state multistep.StateBag) {
 			} else {
 				break
 			}
+		}
+	}
+
+	// restore backed up /etc/resolve.conf in chroot
+	resolve := filepath.Join(imageMountpoint, "/etc/resolv.conf")
+	result, err := deepCompare("/etc/resolve.conf", resolve)
+	if err != nil {
+		ui.Error(fmt.Sprintf("error comparing host and chroot resolve.conf: %v", err))
+	}
+	// restore the backup only if the resolve.conf is unchanged
+	if result {
+		bak := resolve + ".bak"
+
+		err = os.Remove(resolve)
+		if err != nil {
+			ui.Error(fmt.Sprintf("could not remove file %v: %s", err, resolve))
+		}
+		err = renameAndCheck(bak, resolve)
+		if err == nil {
+			ui.Message(fmt.Sprintf("restored '%s'", resolve))
+		} else if errors.Is(err, fs.ErrNotExist) {
+			ui.Error(fmt.Sprintf("'%s' does not exist: %v", bak, err))
+		} else if errors.Is(err, fs.ErrExist) {
+			ui.Error(fmt.Sprintf("'%s' already exists: %v", resolve, err))
+		} else if errors.Is(err, fs.ErrPermission) {
+			ui.Error(fmt.Sprintf("could not restore '%s': %v", resolve, err))
 		}
 	}
 }

--- a/builder/step_setup_chroot.go
+++ b/builder/step_setup_chroot.go
@@ -77,7 +77,7 @@ func renameAndCheck(src, dst string) error {
     }
     return os.Remove(src)
 }
- 
+
 // deepCompare courtesy of https://stackoverflow.com/a/30038571/51016
 const chunkSize = 64000
 
@@ -157,7 +157,7 @@ func (s *StepSetupChroot) Run(ctx context.Context, state multistep.StateBag) mul
 	dst := filepath.Join(imageMountpoint, src)
 	bak := dst + ".bak"
 
-	// backup the /etc/resolv.conf if it exists
+	// backup /etc/resolv.conf if it exists
 	err := renameAndCheck(dst, bak)
 	if err == nil {
 		ui.Message(fmt.Sprintf("backed up '%s' to '%s'", dst, bak))
@@ -176,7 +176,6 @@ func (s *StepSetupChroot) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 	defer source.Close()
 
-	// Should we backup the /etc/resolv.conf if it exist and restore it before creating the final image?
 	destination, err := os.Create(dst)
 	if err != nil {
 		ui.Error(fmt.Sprintf("error while creating destination: %v: '%s'", err, dst))
@@ -184,6 +183,7 @@ func (s *StepSetupChroot) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 	defer destination.Close()
 
+	// copy /etc/resolv.conf to the chroot
 	_, err = io.Copy(destination, source)
 	if err == nil {
 		ui.Message(fmt.Sprintf("copied file from '%s' to '%s'", src, dst))
@@ -239,13 +239,13 @@ func (s *StepSetupChroot) Cleanup(state multistep.StateBag) {
 		}
 	}
 
-	// restore backed up /etc/resolve.conf in chroot
+	// restore backed up /etc/resolv.conf in chroot
 	resolve := filepath.Join(imageMountpoint, "/etc/resolv.conf")
-	result, err := deepCompare("/etc/resolve.conf", resolve)
+	result, err := deepCompare("/etc/resolv.conf", resolve)
 	if err != nil {
-		ui.Error(fmt.Sprintf("error comparing host and chroot resolve.conf: %v", err))
+		ui.Error(fmt.Sprintf("error comparing host and chroot resolv.conf: %v", err))
 	}
-	// restore the backup only if the resolve.conf is unchanged
+	// restore the backup only if resolv.conf is unchanged
 	if result {
 		bak := resolve + ".bak"
 


### PR DESCRIPTION
Copying `/etc/resolv.cong` to chroot while restoring the original file unless it has been changed during provisioning.

There are very likely room for improvements both in algorithm and code, please review carefully before merging!

Change tested on Macbook Pro M1 with [ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz](http://cdimage.ubuntu.com/releases/20.04.2/release/ubuntu-20.04.2-preinstalled-server-arm64+raspi.img.xz) and confirmed working.