### PR TITLE
feat: add raspios lite 32 bit board

### DIFF
--- a/.github/workflows/all-boards.yml
+++ b/.github/workflows/all-boards.yml
@@ -20,6 +20,7 @@ jobs:
           - raspberry-pi/archlinuxarm.json
           - raspberry-pi/raspbian.json
           - raspberry-pi/raspbian-resize.json
+          - raspberry-pi/raspios-lite-arm.json
           - raspberry-pi-3/archlinuxarm.json
           - raspberry-pi-3/raspios-lite-arm64.json
           - raspberry-pi-4/ubuntu_server_20.04_arm64.json

--- a/boards/raspberry-pi/raspios-lite-arm.json
+++ b/boards/raspberry-pi/raspios-lite-arm.json
@@ -1,0 +1,43 @@
+{
+  "variables": {},
+  "builders": [{
+    "type": "arm",
+    "file_urls" : ["https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip"],
+    "file_checksum_url": "https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf-lite.zip.sha256",
+    "file_checksum_type": "sha256",
+    "file_target_extension": "zip",
+    "image_build_method": "reuse",
+    "image_path": "raspios-arm.img",
+    "image_size": "2G",
+    "image_type": "dos",
+    "image_partitions": [
+      {
+        "name": "boot",
+        "type": "c",
+        "start_sector": "8192",
+        "filesystem": "vfat",
+        "size": "256M",
+        "mountpoint": "/boot"
+      },
+      {
+        "name": "root",
+        "type": "83",
+        "start_sector": "532480",
+        "filesystem": "ext4",
+        "size": "0",
+        "mountpoint": "/"
+      }
+    ],
+    "image_chroot_env": ["PATH=/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"],
+    "qemu_binary_source_path": "/usr/bin/qemu-arm-static",
+    "qemu_binary_destination_path": "/usr/bin/qemu-arm-static"
+  }],
+  "provisioners": [    
+    {
+      "type": "shell",
+      "inline": [
+        "touch /tmp/test"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Added configuration file for most recent raspios lite edition supported by all Raspberry Pi models