### PR TITLE
Add vagrant test workflow, enable handling qemu binaries being symlinks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: All
+name: CI
 on:
   push:
     branches:
@@ -51,7 +51,7 @@ jobs:
           path: packer-builder-arm
           key: key-${{ github.sha }}-1
 
-  build:
+  test:
     needs: compile
     strategy:
       fail-fast: false
@@ -112,3 +112,60 @@ jobs:
 
       - name: Build image
         run: sudo ./packer build boards/${{ matrix.boards }}
+
+  test-vagrant:
+    needs: compile
+    runs-on: macos-10.15
+    name: Build board with vagrant
+    steps:
+      - uses: actions/checkout@v3.1.0
+
+      - name: Cache Vagrant boxes
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
+          restore-keys: |
+            ${{ runner.os }}-vagrant-
+
+      - name: Show Vagrant version
+        run: vagrant --version
+
+      - name: Install Vagrant plugins
+        run: |
+          vagrant plugin install vagrant-disksize
+
+      - name: Run vagrant up
+        run: |
+          vagrant up
+
+      - name: Upload source
+        run: |
+          git archive -o repo.tar.gz HEAD
+          vagrant upload repo.tar.gz /home/vagrant/repo.tar.gz
+          vagrant ssh -c " \
+            rm -rf packer-builder-arm && \
+            mkdir packer-builder-arm && \
+            tar -xf repo.tar.gz -C packer-builder-arm \
+          "
+
+      - name: Retrieve cache
+        uses: actions/cache@v3
+        with:
+          path: packer-builder-arm
+          key: key-${{ github.sha }}-1
+
+      - name: Upload packer-build-arm binary
+        run: |
+          vagrant upload packer-builder-arm /home/vagrant/packer-builder-arm/packer-builder-arm
+
+      - name: Build board
+        run: |
+          vagrant ssh -c " \
+            cd packer-builder-arm && \
+            sudo packer build boards/raspberry-pi-3/archlinuxarm.json \
+          "
+
+      - name: Check result
+        run: |
+          vagrant ssh -c "ls -al packer-builder-arm/raspberry-pi-3.img"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,22 +6,24 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "ubuntu/jammy64"
   config.disksize.size = '40GB'
 
   config.vm.provision "shell", inline: <<-SHELL
+    set -o errtrace -o nounset -o pipefail -o errexit
     curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
     sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
 
     apt-get update
-    apt-get install -y git golang qemu-user-static packer libarchive-tools
-    rm -rf packer-builder-arm *>/dev/null
+    apt-get install -y qemu-user-static packer libarchive-tools
+    #apt-get install -y git golang
+    #rm -rf packer-builder-arm *>/dev/null
 
-    git clone https://github.com/mkaczanowski/packer-builder-arm
-    cd packer-builder-arm
-    go mod download
-    go build
+    #git clone https://github.com/mkaczanowski/packer-builder-arm
+    #cd packer-builder-arm
+    #go mod download
+    #go build
 
-    packer build boards/raspberry-pi-3/archlinuxarm.json
+    #packer build boards/raspberry-pi-3/archlinuxarm.json
   SHELL
 end

--- a/builder/step_setup_qemu.go
+++ b/builder/step_setup_qemu.go
@@ -19,6 +19,7 @@ func checkBinfmtMisc(srcPath string) (string, error) {
 		return "", fmt.Errorf("failed to read /proc/sys/fs/binfmt_misc directory: %v", err)
 	}
 
+	srcPathStat, _ := os.Stat(srcPath)
 	for _, file := range files {
 		if file.Name() == "register" || file.Name() == "status" {
 			continue
@@ -36,8 +37,12 @@ func checkBinfmtMisc(srcPath string) (string, error) {
 				continue
 			}
 
-			if fields[0] == "interpreter" && fields[1] == srcPath {
-				return pth, nil
+			if fields[0] == "interpreter" {
+				fieldStat, _ := os.Stat(fields[1])
+				// os.SameFile allows also comparing of sym- and relativ symlinks.
+				if os.SameFile(fieldStat, srcPathStat) {
+					return pth, nil
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Supports newer qemu-user-static versions (like in Ubuntu 22.04) where `/usr/libexec/qemu-binfmt/aarch64-binfmt-P` is registered under `/proc/sys/fs/binfmt_misc` as interpreter that is a relativ symlink, which points to `../../bin/qemu-aarch64-static`. Testing this via vagrant.