### PR TITLE
Add Docker meta for git release/tag based container tagging

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ name: Docker Build and Upload
 on:
   workflow_dispatch:
   push:
+    tags:
+      - 'v*'
     branches: [ master ]
   pull_request:
   schedule:
@@ -12,9 +14,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
-env:
-  DOCKER_TAG: ${{ github.repository_owner }}/packer-builder-arm:latest
 
 jobs:
   docker:
@@ -31,6 +30,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            mkaczanowski/packer-builder-arm
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=match,pattern=v(.*),group=1
+
       #### run lint, build+export, test only on PRs
       - name: Lint
         if: github.event_name == 'pull_request'
@@ -45,13 +55,13 @@ jobs:
           context: .
           file: docker/Dockerfile
           load: true
-          tags: |
-            ${{ env.DOCKER_TAG }}
+          tags: packer-builder-arm:test
+          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Test
         if: github.event_name == 'pull_request'
         run: |
-          docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build ${{ env.DOCKER_TAG }} build boards/raspberry-pi-4/archlinuxarm.json -extra-system-packages=bmap-tools,zstd;
+          docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build packer-builder-arm:test build boards/raspberry-pi-4/archlinuxarm.json -extra-system-packages=bmap-tools,zstd;
           du -h raspberry-pi-4.img
           du -h --apparent-size raspberry-pi-4.img
       ####
@@ -77,6 +87,14 @@ jobs:
           context: .
           file: docker/Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.DOCKER_TAG }}
-          # ghcr.io/${{ github.repository_owner }}/packer-builder-arm:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Update description
+        uses: peter-evans/dockerhub-description@v3
+        if: github.ref == 'refs/heads/master'
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          short-description: Packer plugin to build ARM images
+          readme-filepath: ./README.md


### PR DESCRIPTION
Containers built from master branch on merge/cron builds will be tagged *master*, *latest* will point to the latest version taggeded container.

Also update the docker description on merge as it got out of sync.