### PR TITLE
Improve Mac (Intel/M1) container experience

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,10 +110,10 @@ jobs:
           df -h
 
       - name: Validate
-        run: ./packer validate boards/${{ matrix.boards }}
+        run: PACKER_LOG=1 ./packer validate boards/${{ matrix.boards }}
 
       - name: Build image
-        run: sudo ./packer build boards/${{ matrix.boards }}
+        run: sudo PACKER_LOG=1 ./packer build boards/${{ matrix.boards }}
 
   test-vagrant:
     needs: compile
@@ -165,7 +165,7 @@ jobs:
         run: |
           vagrant ssh -c " \
             cd packer-builder-arm && \
-            sudo packer build boards/raspberry-pi-3/archlinuxarm.json \
+            sudo PACKER_LOG=1 packer build boards/raspberry-pi-3/archlinuxarm.json \
           "
 
       - name: Check result

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
 
   test-vagrant:
     needs: compile
-    runs-on: macos-10.15
+    runs-on: macos-12
     name: Build board with vagrant
     steps:
       - uses: actions/checkout@v3.1.0

--- a/README.md
+++ b/README.md
@@ -59,15 +59,30 @@ go build
 sudo packer build boards/odroid-u3/archlinuxarm.json
 ```
 ## Run in Docker
-This method is primarily for macOS users where is no native way to use qemu-user-static (or Linux users, who do not want to setup packer and all the tools).
+This method is primarily for macOS users where is no native way to use qemu-user-static, loop mount Linux specifc filesystems and install all above mentioned Linux specific tools (or Linux users, who do not want to setup packer and all the tools).
+
+The container is a multi-arch container (linux/amd64 or linux/arm64), that can be used on Intel (x86_64) or Apple M1 (arm64) Macs and also on Linux machines running linux (x86_64 or aarch64) kernels.
+
+> **_NOTE:_** On Macs: Don't run `go build .` (that produces a **darwin** binary) and then run below `docker run ...` commands from the same folder to avoid the error `error initializing builder 'arm': fork/exec /build/packer-builder-arm: exec
+format error` (**linux** packer process within docker fails to load the outside container compiled packer-builder-arm binary due to being a **darwin** binary). Delete any local binary via `rm -r packer-*` to solely use the binary already included and provided by the container.
+
 ### Usage via container from Docker Hub:
+
+Pull the latest version of the container to ensure the next commands are not using an old cached version of the container :
 ```
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm build boards/raspberry-pi/raspbian.json
+docker pull mkaczanowski/packer-builder-arm:latest
 ```
-More system packages (e.g. bmap-tools, zstd) can be added via the parameter `-extra-system-packages=...`:
+
+Build a board:
 ```
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm build boards/raspberry-pi/raspbian.json -extra-system-packages=bmap-tools,zstd
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest build boards/raspberry-pi/raspbian.json
 ```
+Build a board with more system packages (e.g. bmap-tools, zstd) can be added via the parameter `-extra-system-packages=...`:
+```
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest build boards/raspberry-pi/raspbian.json -extra-system-packages=bmap-tools,zstd
+```
+
+> **_NOTE:_** In above commands **latest** can also be replaced via e.g. **1.0.3** to get a specific container version.
 
 ### Usage via local container build (supports amd64/aarch64 hosts):
 Build the container locally:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,4 +52,7 @@ COPY docker/entrypoint.sh /entrypoint.sh
 COPY --from=builder /build/packer-builder-arm /bin/packer /bin/
 COPY --from=binfmt /usr/bin/ /usr/bin
 
+# Enable detailed logging
+ENV PACKER_LOG=1
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,6 @@ RUN apt-get update -qq \
 
 WORKDIR /build
 
-COPY go.mod go.sum ./
-RUN go mod download
 COPY . .
 
 RUN go build -o packer-builder-arm

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,6 +24,13 @@ if [ "${#EXTRA_SYSTEM_PACKAGES[@]}" -gt 0 ]; then
     apt-get install -y --no-install-recommends "${EXTRA_SYSTEM_PACKAGES[@]}"
 fi
 
+for entry in ./packer-*; do
+    if [[ -x "$entry" ]]; then
+        echo "Please remove $entry and try again."
+        exit 1
+    fi
+done
+
 export DONT_SETUP_QEMU=1
 
 echo running "${PACKER}" "${@}"


### PR DESCRIPTION
* Run vagrant test on macos-12: macos-10.15 runners are deprecated now and the macos-11 runners don't
support vagrant.
* Enable extended packer logging to see plugin loading details
* Extend Docker section in README.md regarding mac usage
* Quit docker processing if packer-* binary is found in current folder: To avoid `error initializing builder 'arm': fork/exec /build/packer-builder-arm: exec format error` as mentioned in the README.md.
* Build from local source only in Docker

closes https://github.com/mkaczanowski/packer-builder-arm/issues/130