### PR TITLE
Set Docker platforms for archlinuxarm containers

### DIFF
--- a/.github/workflows/archlinuxarm-armv7-docker.yml
+++ b/.github/workflows/archlinuxarm-armv7-docker.yml
@@ -28,9 +28,6 @@ jobs:
               dep ensure
           fi
 
-      - name: Setup backports
-        run: sudo /bin/bash -c 'echo "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse" >> /etc/apt/sources.list'
-
       - name: Fetch additional packages
         run: |
           sudo apt-get update
@@ -39,8 +36,10 @@ jobs:
       - name: Build
         run: go build -v .
 
-      - name: Fetch packer
-        run: wget https://releases.hashicorp.com/packer/1.8.3/packer_1.8.3_linux_amd64.zip && unzip -d . packer_1.8.3_linux_amd64.zip
+      - name: Install Packer
+        uses: hashicorp-contrib/setup-packer@v2
+        with:
+          packer-version: 1.8.3
 
       - name: Build image
         run: sudo ./packer build -var docker_user=$docker_user -var docker_password=$docker_password -var docker_repository=$docker_repository boards/armv7/archlinuxarm-docker.json

--- a/.github/workflows/archlinuxarm-armv8-docker.yml
+++ b/.github/workflows/archlinuxarm-armv8-docker.yml
@@ -28,9 +28,6 @@ jobs:
               dep ensure
           fi
 
-      - name: Setup backports
-        run: sudo /bin/bash -c 'echo "deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse" >> /etc/apt/sources.list'
-
       - name: Fetch additional packages
         run: |
           sudo apt-get update
@@ -39,11 +36,13 @@ jobs:
       - name: Build
         run: go build -v .
 
-      - name: Fetch packer
-        run: wget https://releases.hashicorp.com/packer/1.8.3/packer_1.8.3_linux_amd64.zip && unzip -d . packer_1.8.3_linux_amd64.zip
+      - name: Install Packer
+        uses: hashicorp-contrib/setup-packer@v2
+        with:
+          packer-version: 1.8.3
 
       - name: Build image
-        run: sudo ./packer build -var docker_user=$docker_user -var docker_password=$docker_password -var docker_repository=$docker_repository boards/armv8/archlinuxarm-docker.json
+        run: sudo packer build -var docker_user=$docker_user -var docker_password=$docker_password -var docker_repository=$docker_repository boards/armv8/archlinuxarm-docker.json
         env:
           docker_user: ${{ secrets.docker_user }}
           docker_password: ${{ secrets.docker_password }}

--- a/boards/armv7/archlinuxarm-docker.json
+++ b/boards/armv7/archlinuxarm-docker.json
@@ -46,7 +46,8 @@
       {
         "type": "docker-import",
         "repository": "{{user `docker_repository`}}",
-        "tag": "armv7"
+        "tag": "armv7",
+        "platform": "linux/arm/v7"
       },
       {
         "type": "docker-push",

--- a/boards/armv8/archlinuxarm-docker.json
+++ b/boards/armv8/archlinuxarm-docker.json
@@ -46,7 +46,8 @@
       {
         "type": "docker-import",
         "repository": "{{user `docker_repository`}}",
-        "tag": "armv8"
+        "tag": "armv8",
+        "platform": "linux/arm64"
       },
       {
         "type": "docker-push",


### PR DESCRIPTION
Also:
* install packer via action
* Remove "Setup Backports" step as not neaded by newer Action Runners and trusty being old (ubuntu-latest runners use 20.04, trusty is 14.04)