### PR TITLE
Fix qemu container integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git*
 boards
+.packer_cache
 packer_cache
 scripts
 *.img

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,10 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Set up QEMU
+        # Required only for the multi-arch container builds that are pushed to Dockerhub.
+        # Setting up QEMU during normal PRs prevents testing of the container included
+        # QEMU setup.
+        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') }}
         uses: docker/setup-qemu-action@v2
         with:
           platforms: linux/amd64,linux/arm64

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,10 @@
-FROM tonistiigi/binfmt:qemu-v7.0.0 AS binfmt
+# Source for qemu-user-static >7.0
+FROM public.ecr.aws/ubuntu/ubuntu:kinetic as qemu_binaries
+
+# hadolint ignore=DL3008
+RUN apt-get update -qq \
+ && apt-get install -qqy --no-install-recommends qemu-user-static
+
 FROM golang:1.19-bullseye AS builder
 
 # hadolint ignore=DL3008
@@ -49,7 +55,8 @@ WORKDIR /build
 
 COPY docker/entrypoint.sh /entrypoint.sh
 COPY --from=builder /build/packer-builder-arm /bin/packer /bin/
-COPY --from=binfmt /usr/bin/ /usr/bin
+# Only copy relevant qemu binaries to save container space
+COPY --from=qemu_binaries /usr/bin/qemu-arm-static /usr/bin/qemu-aarch64-static /usr/bin/
 
 # Enable detailed logging
 ENV PACKER_LOG=1

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,9 +4,33 @@ set -o errtrace -o nounset -o pipefail -o errexit
 
 echo "uname -a: $(uname -a)"
 
-/usr/bin/binfmt --install all
-
 PACKER=/bin/packer
+
+setup_qemu() {
+    # See also:
+    #   * https://github.com/qemu/qemu/blob/master/scripts/qemu-binfmt-conf.sh
+    #   * https://github.com/tonistiigi/binfmt/blob/master/cmd/binfmt/main.go
+    #   * https://docs.kernel.org/admin-guide/binfmt-misc.html
+
+    # mount binfmt_misc to be able to register qemu binaries
+    mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
+
+    # reset
+    find /proc/sys/fs/binfmt_misc -type f -name 'qemu-*' -exec sh -c 'echo -1 > "$1"' shell {} \;
+
+    uname_m="$(uname -m)"
+    if [ "$uname_m" != "aarch64" ]; then
+        echo "Register qemu-aarch64"
+        echo ":qemu-aarch64:M::\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\xb7\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-aarch64-static:F" > /proc/sys/fs/binfmt_misc/register
+    fi
+    echo "Register qemu-arm"
+    echo ":qemu-arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:F" > /proc/sys/fs/binfmt_misc/register
+}
+
+do_qemu_setup=${SETUP_QEMU:-true}
+if [ "$do_qemu_setup" = true ]; then
+    setup_qemu
+fi
 
 declare -a EXTRA_SYSTEM_PACKAGES=()
 for arg do


### PR DESCRIPTION
packer-builder-arm is using qemu in order to emulate the arm target platform when provisioning arm machine images.

The Docker Container therefor contains embedded qemu binaries and some setup code to register those when using the container. This integration didn't work and that was not caught by the Github workflows due the `docker/setup-qemu-action` always being running as part of the docker workflow. The usage of `docker/setup-qemu-action` enables two things: 1. building multi-arch containers 2. running binaries of other platforms inside a container. The later should be covered by the qemu binaries+setup we integrated into the container. By setting up `docker/setup-qemu-action` only when we build+push multi-arch containers on the master-brach/release, we get the qemu integration tested during PR test builds. So we get that tested, but how to resolve the issue of the not working qemu integration?

This are afaik the most used qemu binaries:
1. Delivered by the container from https://github.com/tonistiigi/binfmt with huge amount of downloads due to a very wide usage by `docker/setup-qemu-action`. They maintain there own patches and it also works in our case by using the action or running the container before the packer run. But copying the binaries into our container did not work so far (why?).
2. Also widely used is https://github.com/multiarch/qemu-user-static, but only provides binaries for x86_64 hosts, which is not sufficient for creating linux-aarch64 containers useable on M1 MACs.
3. The qemu-user-static packages as part of various distributions. Those work, but the Debian/Ubuntu tool `update-binfmts` to register the binaries does not register `qemu-arm-static` in case of a linux-aarch64 host, which leads to packer again not working.

What this PR now does is combining the binaries from 3. with registering also the qemu-arm-static binary on linux-aarch64 like done by 1. 

The resulting container should now work on the following platforms
* on x86_64 Linux (using the integrated qemu, without any previous docker qemu enablement required)
* on x86_64 macOS (using the integrated qemu, without any previous docker qemu enablement required)
* on arm64 macOS (Apple M1/M2) (using the integrated qemu, without any previous docker qemu enablement required)
* on any of the above by disabling the integrated qemu:
  * by enabling docker qemu integration via `docker/setup-qemu-action` (= locally `docker run --privileged --rm tonistiigi/binfmt --install all`)
  * running our container via: `docker run -e SETUP_QEMU=false --rm --privileged -v /dev:/dev -v ${PWD}:/build --entrypoint /bin/bash -it mkaczanowski/packer-builder-arm`

Found by the experiments in https://github.com/mkaczanowski/packer-builder-arm/pull/249

cc: @benalexau @openoms who reported this.

fixes: https://github.com/mkaczanowski/packer-builder-arm/issues/244
fixes: https://github.com/mkaczanowski/packer-builder-arm/issues/245