### PR TITLE
Add repartition mode

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -149,6 +149,18 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			&StepMountImage{FromKey: "image_loop_device", ResultKey: "image_mountpoint", MountPath: b.config.ImageMountPath},
 		)
 
+	case "repartition":
+		steps = append(
+			steps,
+			&StepExtractAndCopyImage{FromKey: "rootfs_archive_path"},
+			&StepResizeQemuImage{},
+			&StepPartitionImage{},
+			&StepMapImage{ResultKey: "image_loop_device"},
+			&StepMkfsImage{FromKey: "image_loop_device"},
+			&StepResizePartitionFs{FromKey: "image_loop_device"},
+			&StepMountImage{FromKey: "image_loop_device", ResultKey: "image_mountpoint", MountPath: b.config.ImageMountPath},
+		)
+
 	default:
 		return nil, errors.New("invalid build method")
 	}

--- a/builder/step_mkfs_image.go
+++ b/builder/step_mkfs_image.go
@@ -22,6 +22,11 @@ func (s *StepMkfsImage) Run(_ context.Context, state multistep.StateBag) multist
 	loopDevice := state.Get(s.FromKey).(string)
 
 	for i, partition := range config.ImageConfig.ImagePartitions {
+		if partition.SkipMkfs {
+			ui.Message(fmt.Sprintf("skipping mkfs for partition #%d", i+1))
+			continue
+		}
+
 		cmd := fmt.Sprintf("mkfs.%s", partition.Filesystem)
 		args := append(partition.FilesystemMakeOptions, fmt.Sprintf("%sp%d", loopDevice, i+1))
 

--- a/builder/step_resize_partition_fs.go
+++ b/builder/step_resize_partition_fs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/mkaczanowski/packer-builder-arm/config"
 )
 
 // StepResizePartitionFs expand already partitioned image
@@ -15,21 +16,48 @@ type StepResizePartitionFs struct {
 	SelectedPartitionKey string
 }
 
+// Find partitions marked with ResizeFs that we explicitly want to resize
+func findPartitionsToResize(imagePartitions []config.Partition) []int {
+	var selectedPartitions []int
+
+	for i, partition := range imagePartitions {
+		if partition.ResizeFs {
+			selectedPartitions = append(selectedPartitions, i+1)
+		}
+	}
+
+	return selectedPartitions
+}
+
 // Run the step
 func (s *StepResizePartitionFs) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	var (
-		ui = state.Get("ui").(packer.Ui)
-
-		loopDevice        = state.Get(s.FromKey).(string)
-		selectedPartition = state.Get(s.SelectedPartitionKey).(int)
-		device            = fmt.Sprintf("%sp%d", loopDevice, selectedPartition)
+		ui         = state.Get("ui").(packer.Ui)
+		loopDevice = state.Get(s.FromKey).(string)
 	)
 
-	out, err := exec.Command("resize2fs", "-f", device).CombinedOutput()
-	ui.Message(fmt.Sprintf("running resize2fs on %s ", device))
-	if err != nil {
-		ui.Error(fmt.Sprintf("error while resizing partition %v: %s", err, out))
-		return multistep.ActionHalt
+	var selectedPartitions []int
+
+	// If we're running in resize mode, we'll have a single selected partition
+	// to resize from StepExpandPartition, and we can be sure we don't need to
+	// expand any other partitions. If we're in repartition mode, we manually
+	// choose which partitions to resize: only the user knows which ones
+	// have been expanded.
+	if s.SelectedPartitionKey != "" {
+		selectedPartitions = append(selectedPartitions, state.Get(s.SelectedPartitionKey).(int))
+	} else {
+		config := state.Get("config").(*Config)
+		selectedPartitions = findPartitionsToResize(config.ImagePartitions)
+	}
+
+	for _, partition := range selectedPartitions {
+		device := fmt.Sprintf("%sp%d", loopDevice, partition)
+		out, err := exec.Command("resize2fs", "-f", device).CombinedOutput()
+		ui.Message(fmt.Sprintf("running resize2fs on %s ", device))
+		if err != nil {
+			ui.Error(fmt.Sprintf("error while resizing partition %v: %s", err, out))
+			return multistep.ActionHalt
+		}
 	}
 
 	return multistep.ActionContinue

--- a/config/image_config.go
+++ b/config/image_config.go
@@ -19,6 +19,8 @@ type Partition struct {
 	Filesystem            string   `mapstructure:"filesystem"`
 	FilesystemMakeOptions []string `mapstructure:"filesystem_make_options"`
 	Mountpoint            string   `mapstructure:"mountpoint"`
+	ResizeFs              bool     `mapstructure:"resize_fs"`
+	SkipMkfs              bool     `mapstructure:"skip_mkfs"`
 }
 
 // ChrootMount describes a mountpoint that is being setup
@@ -74,8 +76,8 @@ func (c *ImageConfig) Prepare(_ *interpolate.Context) (warnings []string, errs [
 		errs = append(errs, errors.New("image build method must be specified"))
 	}
 
-	if !(c.ImageBuildMethod == "new" || c.ImageBuildMethod == "reuse" || c.ImageBuildMethod == "resize") {
-		errs = append(errs, errors.New("invalid image build method specified (valid options: new, reuse)"))
+	if !(c.ImageBuildMethod == "new" || c.ImageBuildMethod == "reuse" || c.ImageBuildMethod == "resize" || c.ImageBuildMethod == "repartition") {
+		errs = append(errs, errors.New("invalid image build method specified (valid options: new, reuse, resize, repartition)"))
 	}
 
 	if len(c.ImagePartitions) == 0 {

--- a/config/image_config.hcl2spec.go
+++ b/config/image_config.hcl2spec.go
@@ -45,6 +45,8 @@ type FlatPartition struct {
 	Filesystem            *string  `mapstructure:"filesystem" cty:"filesystem" hcl:"filesystem"`
 	FilesystemMakeOptions []string `mapstructure:"filesystem_make_options" cty:"filesystem_make_options" hcl:"filesystem_make_options"`
 	Mountpoint            *string  `mapstructure:"mountpoint" cty:"mountpoint" hcl:"mountpoint"`
+	ResizeFs              *bool    `mapstructure:"resize_fs" cty:"resize_fs" hcl:"resize_fs"`
+	SkipMkfs              *bool    `mapstructure:"skip_mkfs" cty:"skip_mkfs" hcl:"skip_mkfs"`
 }
 
 // FlatMapstructure returns a new FlatPartition.
@@ -67,6 +69,8 @@ func (*FlatPartition) HCL2Spec() map[string]hcldec.Spec {
 		"filesystem":              &hcldec.AttrSpec{Name: "filesystem", Type: cty.String, Required: false},
 		"filesystem_make_options": &hcldec.AttrSpec{Name: "filesystem_make_options", Type: cty.List(cty.String), Required: false},
 		"mountpoint":              &hcldec.AttrSpec{Name: "mountpoint", Type: cty.String, Required: false},
+		"resize_fs":               &hcldec.AttrSpec{Name: "resize_fs", Type: cty.Bool, Required: false},
+		"skip_mkfs":               &hcldec.AttrSpec{Name: "skip_mkfs", Type: cty.Bool, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
## Description

This PR creates a new image build method, `repartition`, which doesn't add much (or any, really) new functionality, but rather re-uses existing steps, effectively combining the `new` and `resize` methods.

This allows the user to, using a raw image file as a basis:

* Overwrite the image's partition table with whatever content they define (via the existing `image_partitions` config)
* Format newly created partitions with `mkfs` (the user chooses which partitions they want to format, as we don't know which ones are 'newly created' since we don't parse partition tables of existing images)
* Resize the ext{2,3,4} filesystems of resized partitions with `resize2fs`

This is something that was especially useful in my particular use-case, but I think it could be useful more widely as well, hence this PR :)

## Use-cases

* Grow/shrink a partition in an existing image
* Create new partitions at the end of the image file
  * Swap partition
  * Separate `/home` partition
* Destroy an unwanted partition in an existing image

## Backwards compatibility

I've tried to make this change entirely backwards-compatible, so that no existing builds will be affected by it.

To do this:

* `skip_mkfs` defaults to false, and hence the Mkfs step behaviour is unchanged (it's only currently used with the `new` method, as far as I can tell, in which case we *shouldn't* be skipping it by default for any partitions)
* `resize_fs` only has an effect when using the repartition method, and hence the behaviour of the resize step should be unchanged

