### PR TITLE
Rename go package for fork (a go conceptual weakness)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            mkaczanowski/packer-builder-arm
+            brederle/packer-plugin-armflash
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 [![Docker Image Size][docker-size]][docker-hub]
 [![Docker Image Version][docker-version]][docker-hub]
 
-[github-badge]:https://img.shields.io/github/actions/workflow/status/mkaczanowski/packer-builder-arm/docker.yml?branch=master
-[github]: https://github.com/mkaczanowski/packer-builder-arm/actions
-[godoc-badge]: https://godoc.org/github.com/mkaczanowski/packer-builder-arm?status.svg
-[godoc]: https://godoc.org/github.com/mkaczanowski/packer-builder-arm
-[report-badge]: https://goreportcard.com/badge/github.com/mkaczanowski/packer-builder-arm
-[report]: https://goreportcard.com/report/github.com/mkaczanowski/packer-builder-arm
-[docker-hub]: https://hub.docker.com/r/mkaczanowski/packer-builder-arm
-[docker-pulls]: https://img.shields.io/docker/pulls/mkaczanowski/packer-builder-arm
-[docker-size]: https://img.shields.io/docker/image-size/mkaczanowski/packer-builder-arm
-[docker-version]: https://img.shields.io/docker/v/mkaczanowski/packer-builder-arm?sort=semver
+[github-badge]:https://img.shields.io/github/actions/workflow/status/brederle/packer-plugin-armflash/docker.yml?branch=master
+[github]: https://github.com/brederle/packer-plugin-armflash/actions
+[godoc-badge]: https://godoc.org/github.com/brederle/packer-plugin-armflash?status.svg
+[godoc]: https://godoc.org/github.com/brederle/packer-plugin-armflash
+[report-badge]: https://goreportcard.com/badge/github.com/brederle/packer-plugin-armflash
+[report]: https://goreportcard.com/report/github.com/brederle/packer-plugin-armflash
+[docker-hub]: https://hub.docker.com/r/brederle/packer-plugin-armflash
+[docker-pulls]: https://img.shields.io/docker/pulls/brederle/packer-plugin-armflash
+[docker-size]: https://img.shields.io/docker/image-size/brederle/packer-plugin-armflash
+[docker-version]: https://img.shields.io/docker/v/brederle/packer-plugin-armflash?sort=semver
 
 
 This plugin allows you to build or extend ARM system image. It operates in two modes:
@@ -51,7 +51,7 @@ Since the setup varies a lot for different hardware types, the example configura
 
 # Quick start
 ```
-git clone https://github.com/mkaczanowski/packer-builder-arm
+git clone https://github.com/brederle/packer-plugin-armflash
 cd packer-builder-arm
 go mod download
 go build
@@ -70,16 +70,16 @@ format error` (**linux** packer process within docker fails to load the outside 
 
 Pull the latest version of the container to ensure the next commands are not using an old cached version of the container :
 ```
-docker pull mkaczanowski/packer-builder-arm:latest
+docker pull brederle/packer-plugin-armflash:latest
 ```
 
 Build a board:
 ```
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest build boards/raspberry-pi/raspbian.json
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build brederle/packer-plugin-armflash:latest build boards/raspberry-pi/raspbian.json
 ```
 Build a board with more system packages (e.g. bmap-tools, zstd) can be added via the parameter `-extra-system-packages=...`:
 ```
-docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build mkaczanowski/packer-builder-arm:latest build boards/raspberry-pi/raspbian.json -extra-system-packages=bmap-tools,zstd
+docker run --rm --privileged -v /dev:/dev -v ${PWD}:/build brederle/packer-plugin-armflash:latest build boards/raspberry-pi/raspbian.json -extra-system-packages=bmap-tools,zstd
 ```
 
 > **_NOTE:_** In above commands **latest** can also be replaced via e.g. **1.0.3** to get a specific container version.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
     #apt-get install -y git golang
     #rm -rf packer-builder-arm *>/dev/null
 
-    #git clone https://github.com/mkaczanowski/packer-builder-arm
+    #git clone https://github.com/brederle/packer-plugin-armflash
     #cd packer-builder-arm
     #go mod download
     #go build

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
-	cfg "github.com/mkaczanowski/packer-builder-arm/config"
+	cfg "github.com/brederle/packer-plugin-armflash/config"
 )
 
 // Config top-level holder for more specific configurations used

--- a/builder/builder.hcl2spec.go
+++ b/builder/builder.hcl2spec.go
@@ -4,7 +4,7 @@ package builder
 
 import (
 	"github.com/hashicorp/hcl/v2/hcldec"
-	"github.com/mkaczanowski/packer-builder-arm/config"
+	"github.com/brederle/packer-plugin-armflash/config"
 	"github.com/zclconf/go-cty/cty"
 )
 

--- a/builder/step_mount_image.go
+++ b/builder/step_mount_image.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
-	cfg "github.com/mkaczanowski/packer-builder-arm/config"
+	cfg "github.com/brederle/packer-plugin-armflash/config"
 )
 
 func sortMountablePartitions(partitions []cfg.Partition, reverse bool) []cfg.Partition {

--- a/builder/step_setup_chroot.go
+++ b/builder/step_setup_chroot.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packer"
-	cfg "github.com/mkaczanowski/packer-builder-arm/config"
+	cfg "github.com/brederle/packer-plugin-armflash/config"
 )
 
 func sortMountpoints(chrootMounts []cfg.ChrootMount, reverse bool) []cfg.ChrootMount {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mkaczanowski/packer-builder-arm
+module github.com/brederle/packer-plugin-armflash
 
 go 1.20
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/packer-plugin-sdk/plugin"
-	"github.com/mkaczanowski/packer-builder-arm/builder"
+	"github.com/brederle/packer-plugin-armflash/builder"
 )
 
 func main() {


### PR DESCRIPTION
We need to rename the go package name for 2 reasons:

1. the package will not build with the original name of `mkaczanowski/packer-builder-arm`
    (I personally would have preferred a better solution, but internet gave me none)
2. The packer 1.11 breaking packer plugin sdk changes require a base package name according
     to the scheme `github.com/<organisation>/packer-plugin-<name>`

`arm`is somehow a poor plugin name, so I have chosen `armflash` as plugin name as it describes
better the purpose of this plugin - to build native arm flash images.  